### PR TITLE
Removed multiplexer customization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,6 @@ Would you like to help with this project? Feel free to make a pull request!
   - Give coordinates for each sensor to match a specific shape if necessary (i.e. of a PCB)
   - Give each sensor a label on the graph (i.e an ID to do something very specific).
 - visualisation.ino
-  - Allow use of a multiplexer if required
   - Allow use of EEPROM to receive values if required
 
 ## Installation

--- a/firmware/visualisation.ino
+++ b/firmware/visualisation.ino
@@ -2,44 +2,25 @@
 
 // CONFIGURABLE SETTINGS
 
-/**
- * @brief Define the amount of sensors / the amount you're expecting to read
- * @note if you use a multiplexer, the amount of sensors can be more than the
- * amount of analog pins.
- */
-const int SENSOR_BUFFER_SIZE = 16;
-
 // ! set threshold values manually if EEPROM is not used
 const bool useEEPROM = false;
 int eepromAddress = -1;
-
-// turn on and define pin for multiplexer
-const bool useMultiplexer = false;
-int multiplexerPin = -1;
 
 // Define analog pins used for sensors, customize these manually
 const int analogPins[] = {A0, A1, A2,  A3,  A4,  A5,  A6,  A7,
                           A8, A9, A10, A11, A12, A13, A14, A15};
 
-// pinCount != sensor buffer size if multiplexer is used
 const int pinCount = sizeof(analogPins) / sizeof(analogPins[0]);
 
 // total expected values to be read
-int sensorsInput[SENSOR_BUFFER_SIZE];
-int sensorThreshold[SENSOR_BUFFER_SIZE] = {
-    -1, -1, -1, -1, /* ... up to SENSOR_BUFFER_SIZE values ... */};
+int sensorsInput[pinCount];
+int sensorThreshold[pinCount];
 
 void setup() {
   Serial.begin(115200);
 
-  while (pinCount > SENSOR_BUFFER_SIZE) {
-    Serial.println("Error: Amount of analog pins exceeds sensor buffer size.");
-    delay(1000);
-  }
-
-  if (useMultiplexer && multiplexerPin >= 0) {
-    pinMode(multiplexerPin, OUTPUT);
-  }
+  int sensorThreshold[pinCount] = {-1, -1, -1, -1, -1, -1, -1, -1,
+                                   -1, -1, -1, -1, -1, -1, -1, -1};
 
   // make sure to set the EEPROM address if used
   // Make sure the size is within sensorThreshold array bounds
@@ -50,6 +31,7 @@ void setup() {
 
 void loop() {
 
+  // Receives "R" from main.py after running the script
   if (Serial.available() && Serial.read() == 'R') {
     readSensors();
     sendSensorData();
@@ -58,39 +40,33 @@ void loop() {
   delay(10);
 }
 
+/**
+ * @brief Read sensors from analog pins and store in sensorsInput array
+ * @note This function reads the analog values from the defined pins
+ * and stores them in the sensorsInput array.
+ */
 void readSensors() {
 
-  if (useMultiplexer && multiplexerPin >= 0) {
-
-    // ! assuming the total amount of sensors is twice the amount of analog pins
-    // (pinCount)
-    //  adjust as needed for your specific multiplexer setup
-    digitalWrite(multiplexerPin, LOW);
-    for (int i = 0; i < pinCount; i++) {
-      sensorsInput[i] = analogRead(analogPins[i]);
-    }
-
-    digitalWrite(multiplexerPin, HIGH);
-    for (int i = 0; i < pinCount; i++) {
-      sensorsInput[pinCount + i] = analogRead(analogPins[i]);
-    }
-  } else {
-    for (int i = 0; i < pinCount; i++) {
-      sensorsInput[i] = analogRead(analogPins[i]);
-    }
+  for (int i = 0; i < pinCount; i++) {
+    sensorsInput[i] = analogRead(analogPins[i]);
   }
 }
 
+/**
+ * @brief Sending over serial for main.py to read
+ * @note main.py assumes data is split by commas,
+ * if you change this then change it there too
+ */
 void sendSensorData() {
 
-  for (int i = 0; i < SENSOR_BUFFER_SIZE; i++) {
+  for (int i = 0; i < pinCount; i++) {
     Serial.print(sensorsInput[i]);
     Serial.print(",");
   }
 
-  for (int i = 0; i < SENSOR_BUFFER_SIZE; i++) {
+  for (int i = 0; i < pinCount; i++) {
     Serial.print(sensorThreshold[i]);
-    if (i < SENSOR_BUFFER_SIZE - 1)
+    if (i < pinCount - 1)
       Serial.print(",");
   }
   Serial.println(); // End transmission


### PR DESCRIPTION
Due to many types of multiplexers and different ways someone could apply them, it's hard to allow customization that fits everyone (with my knowledge). They would have to add a lot themselves, probably. 

So I'm making the default no multiplexer until I can find a way to make this easier. 
Maybe I'll use AI to think of a solution? Would have to test that then, but for now. No multiplexer 

Issue for this created at [!](https://github.com/sSpectrals/phototransistor-visualiser-app/issues/22#issue-3231648165)